### PR TITLE
Python divisibility rule

### DIFF
--- a/Kotlin/FizzBuzz-OneLine.kt
+++ b/Kotlin/FizzBuzz-OneLine.kt
@@ -1,0 +1,3 @@
+// Kotlin in one line
+// Author: @veotani
+fun main(args: Array<String>) { println(((1..100).map{ if (it % 15 == 0) "FizzBuzz" else if (it % 3 == 0) "Fizz" else if (it % 5 == 0) "Buzz" else it.toString()}).joinToString(separator = "\n")) }

--- a/Python/FizzBuzzDivisibilityRule.py
+++ b/Python/FizzBuzzDivisibilityRule.py
@@ -1,0 +1,22 @@
+# Using divisibility rule to determine what line to print
+# Author: @veotani
+def divisibility_rule_3(number):
+    if number < 10:
+        return number in {0, 3, 6, 9}
+    return divisibility_rule_3(sum([int(digit) for digit in str(number)]))
+
+def divisibility_rule_5(number):
+    return int(str(number)[-1]) in {0, 5}
+
+def divisibility_rule_15(number):
+    return divisibility_rule_5(number) and divisibility_rule_3(number)
+
+for number in range(1, 101):
+    if divisibility_rule_15(number):
+        print('FizzBuzz')
+    elif divisibility_rule_3(number):
+        print('Fizz')
+    elif divisibility_rule_5(number):
+        print('Buzz')
+    else:
+        print(number)


### PR DESCRIPTION
Using divisibility rule to determine text to be printed. Mods and Divs are not used in this implementation.