### PR TITLE
Add vanilla nix solution

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,49 @@
+# Vanilla implementation in nix (The language for the package manager nix)
+# Author: @CRTified
+
+{pkgs ? (import <nixos> {})}:
+
+with pkgs.lib;
+let
+  # Check for divisibility by 3 by:
+  # - Checking against a list if n is single-digit
+  # - Calculating the sum of digits otherwise, checking its divisibility by 3
+  divisibleBy3 = n:
+    if (stringLength "${toString n}") > 1 then
+      divisibleBy3 (foldr
+        (v: acc: (toInt v) + acc)
+        0
+        (stringToCharacters (toString n))
+      )
+    else
+      elem n [0 3 6 9];
+
+  # Check  for divisibility by 5 by:
+  # Checking if the last digit is 0 or 5
+  divisibleBy5 = n:
+    let
+      lastChar = last (stringToCharacters (toString n));
+    in
+      elem lastChar [ "0" "5" ];
+
+  # Build FizzBuzz String
+  fizzbuzz = v:
+    let
+      isDiv3 = divisibleBy3 v;
+      isDiv5 = divisibleBy5 v;
+    in
+      if isDiv3 && isDiv5 then
+        "FizzBuzz"
+      else if isDiv5 then
+        "Buzz"
+      else if isDiv3 then
+        "Fizz"
+      else
+        toString v;
+in
+pkgs.writeText
+  "fizzbuzz.txt"
+  (concatStringsSep
+    "\n"
+    (map fizzbuzz (range 1 100)) # Apply on all numbers between 1 and 100
+  )


### PR DESCRIPTION
This solution creates the result as a file `fizzbuzz.txt` in the nix store.

Here is the result when building with `nix-build`:

```
$ nix-build             
/nix/store/a4ml22idj73gjzc402hx528xas3lz3n4-fizzbuzz.txt
$ cat result 
1
2
Fizz
4
Buzz
Fizz
7
8
Fizz
Buzz
11
Fizz
13
14
FizzBuzz
16
17
Fizz
19
Buzz
Fizz
22
23
Fizz
Buzz
26
Fizz
28
29
FizzBuzz
31
32
Fizz
34
Buzz
Fizz
37
38
Fizz
Buzz
41
Fizz
43
44
FizzBuzz
46
47
Fizz
49
Buzz
Fizz
52
53
Fizz
Buzz
56
Fizz
58
59
FizzBuzz
61
62
Fizz
64
Buzz
Fizz
67
68
Fizz
Buzz
71
Fizz
73
74
FizzBuzz
76
77
Fizz
79
Buzz
Fizz
82
83
Fizz
Buzz
86
Fizz
88
89
FizzBuzz
91
92
Fizz
94
Buzz
Fizz
97
98
Fizz
Buzz
```