### PR TITLE
Add rust proc macro which generates a hardcoded solution

### DIFF
--- a/Rust/macrobuzz.rs
+++ b/Rust/macrobuzz.rs
@@ -1,0 +1,42 @@
+extern crate proc_macro;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+const MAX_FIZZBUZZ: u32 = 100;
+
+#[proc_macro]
+pub fn fizzbuzz(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let precomputed: Vec<TokenStream> = (1..=MAX_FIZZBUZZ).map(|num| {
+        if num % 3 == 0 && num % 5 == 0 {
+            quote! {
+                #num => println!("FizzBuzz")
+            }
+        } else if num % 3 == 0 {
+            quote! {
+                #num => println!("Fizz")
+            }
+        } else if num % 5 == 0 {
+            quote! {
+                #num => println!("Buzz")
+            }
+        } else {
+            let numstr = num.to_string();
+            quote! {
+                #num => println!(#numstr)
+            }
+        }
+    }).collect();
+
+    let output: proc_macro2::TokenStream = quote! {
+        const MAX_FIZZBUZZ: u32 = #MAX_FIZZBUZZ;
+        fn main() {
+            (1..=MAX_FIZZBUZZ).for_each(|num: u32| {
+                match num {
+                    #(#precomputed),*
+                    ,_ => panic!("Whoops")
+                }
+            });
+        }
+    };
+    output.into()
+}


### PR DESCRIPTION
Unsure how meta we're allowed to get with the repo, but this contribution generates a hardcoded fizzbuzz solution in rust (it dynamically builds a match statement with N branches, where it prints the solution for the specific number).

Sadly, due to restrictions in the language, it requires two separate cargo projects to actually run it (one to compile the proc macro, and one project to use it).

If this is too meta, I can always write a standalone version with the macro_rules macro (but proc macros are a tad cooler imo)