### PR TITLE
Aesthetic changes to VBA files

### DIFF
--- a/VBA/FizzBuzzAccess.vba
+++ b/VBA/FizzBuzzAccess.vba
@@ -5,7 +5,7 @@ Sub FizzBuzz()
 ' This subroutine assumes that it is being run in a new database.
 
     DoCmd.Close  ' Close the automatically opened Table1
-    
+
     ' The following creates a new table for the output FizzBuzz result.
     Dim dbs As Database
     Dim tbl As TableDef
@@ -17,11 +17,11 @@ Sub FizzBuzz()
     tbl.Fields.Append fld
     dbs.TableDefs.Append tbl
     dbs.TableDefs.Refresh
-    
+
     DoCmd.OpenTable ("FizzBuzz")  ' Open the FizzBuzz table
 
     DoCmd.SetWarnings False  ' Turn off possible script-interrupting warnings
-    
+
     For i = 1 To 100
         If (i Mod 15) = 0 Then
             DoCmd.RunSQL "INSERT INTO FizzBuzz (Result) VALUES ('FizzBuzz');"
@@ -33,8 +33,8 @@ Sub FizzBuzz()
             DoCmd.RunSQL "INSERT INTO FizzBuzz (Result) VALUES (" & CStr(i) & ");"
         End If
     Next i
-    
+
     DoCmd.SetWarnings True  ' Turn warnings back on for safety
-    
+
     DoCmd.Requery  ' Refresh database to display the output FizzBuzz result
 End Sub

--- a/VBA/FizzBuzzPowerPoint.vba
+++ b/VBA/FizzBuzzPowerPoint.vba
@@ -4,6 +4,12 @@
 Sub FizzBuzz()
 ' This subroutine assumes that it is being run in a new presentation.
 
+    ' The following sets the page to be 2 inches wide by 31 inches high.
+    With ActivePresentation.PageSetup
+        .SlideWidth = 2 * 72
+        .SlideHeight = 31 * 72
+    End With
+
     ' The following clears the presentation
     For i = ActivePresentation.Slides(1).Shapes.Count To 1 Step -1
         ActivePresentation.Slides(1).Shapes(i).Delete
@@ -13,8 +19,8 @@ Sub FizzBuzz()
     Dim objSl As Slide
     Dim objSh As Shape
     Set objSl = ActivePresentation.Slides(1)
-    Set objSh = objSl.Shapes.AddTextbox(msoTextOrientationHorizontal, 0, 0, 100, 100)
-    
+    Set objSh = objSl.Shapes.AddTextbox(msoTextOrientationHorizontal, 20, 20, 100, 100)
+
     For i = 1 To 100
         If (i Mod 15) = 0 Then
             Application.ActivePresentation.Slides(1).Shapes(1).TextFrame.TextRange.InsertAfter "FizzBuzz" & vbCrLf
@@ -26,4 +32,6 @@ Sub FizzBuzz()
             Application.ActivePresentation.Slides(1).Shapes(1).TextFrame.TextRange.InsertAfter i & vbCrLf
         End If
     Next
+
+    Windows(1).View.Zoom = 100  ' Set zoom level to 100%
 End Sub

--- a/VBA/FizzBuzzPublisher.vba
+++ b/VBA/FizzBuzzPublisher.vba
@@ -27,6 +27,6 @@ Sub FizzBuzz()
             Application.ActiveDocument.Pages(1).Shapes(1).TextFrame.TextRange.InsertAfter i & vbCrLf
         End If
     Next
-    
+
     ActiveDocument.ActiveView.Zoom = 100  ' Set zoom level to 100%
 End Sub


### PR DESCRIPTION
This pull request consists of one output aesthetic change, and two practically unnoticeable (to most) changes:

- `FizzBuzzPowerPoint.vba`: Previously the output textbox would exceed the size of the slide. This has now been fixed by making the slide the correct size to accommodate the output textbox. The solution also ends by setting the zoom level of the slide to a comfortable and readable level.
- `FizzBuzzAccess.vba`: Removed extra whitespace in the code - nobody but me will notice this.
- `FizzBuzzPublisher.vba`: Removed extra whitespace in the code - again, nobody but me will notice this.