### PR TITLE
Add Lua/fizzbuzz_subtable_function

### DIFF
--- a/Lua/fizzbuzz_subtable_function.lua
+++ b/Lua/fizzbuzz_subtable_function.lua
@@ -1,0 +1,28 @@
+-- This one creates a table with a metatable attached that allows to unconditionally insert text fragments.
+-- It then uses that table to insert Fizz/Buzz fragments at the correct positions.
+-- Finally, a function is generated that uses this table to concat the fragments, if any.
+-- Author: @PotcFdk
+
+local META = {
+	__index = function (tab, key)
+		tab [key] = rawget (tab, key) or {}
+		return rawget (tab, key)
+	end
+}
+
+local function makeFizzBuzz (start, fin)
+	local output = setmetatable({}, META)
+	for i = start, fin do
+		if i % 3 == 0 then table.insert (output [i], "Fizz") end
+		if i % 5 == 0 then table.insert (output [i], "Buzz") end
+	end
+	return function (key)
+		return rawget (output, key) and table.concat (rawget (output, key), "") or key
+	end
+end
+
+local FizzBuzz = makeFizzBuzz (1, 100)
+
+for i = 1, 100 do
+	print (FizzBuzz (i))
+end


### PR DESCRIPTION
Solution using a temporary table that is filled with Fizz and/or Buzz strings at the correct positions. The table auto-initializes subtables on the first index access. The result of the interface is an anonymous function that ignores the `__index` metafunction using `rawget` and concatenates the strings (or falls back to returning just the number).