### PR TITLE
Add Coq solution

### DIFF
--- a/Coq/solution.v
+++ b/Coq/solution.v
@@ -1,0 +1,72 @@
+(*
+  Coq solution from someone who has no clue
+  Author: @CRTified
+*)
+Require Import List.
+Require Import Strings.String.
+Require Import Strings.Ascii.
+
+
+Open Scope char_scope.
+
+Definition digitToStr n : ascii :=
+  match n with
+  | 0 => "0"
+  | 1 => "1"
+  | 2 => "2"
+  | 3 => "3"
+  | 4 => "4"
+  | 5 => "5"
+  | 6 => "6"
+  | 7 => "7"
+  | 8 => "8"
+  | _ => "9"
+  end.
+
+
+Fixpoint natToStr (time n: nat) (acc: string) : string :=
+  let acc' := String (digitToStr (Nat.modulo n 10)) acc in
+  match time with
+  | 0 => acc'
+  | S time' => match (Nat.div n 10) with
+               | 0 => acc'
+               | n' => natToStr time' n' acc'
+               end
+ end.
+
+
+Definition cfizz x := Nat.modulo x 3.
+Definition cbuzz x := Nat.modulo x 5.
+Definition cfizzbuzz x := Nat.modulo x 15.
+
+Definition fizzle x :=
+    match x with
+    | 0 => ""%string
+    | _ =>
+      match cfizzbuzz x with
+      | 0 => "FizzBuzz"%string
+      | _ => match cfizz x with
+             | 0 => "Fizz"%string
+             | _ => match cbuzz x with
+                    | 0 => "Buzz"%string
+                    | _ => natToStr x x ""
+                    end
+             end
+      end
+    end.
+
+
+Import ListNotations.
+
+Fixpoint fizzleList (time: nat) (l: list nat) (acc: string) : string :=
+  let acc' := String.append (String.append acc " ") (fizzle (List.hd 0 l)) in
+  match time with
+  | 0 => acc'
+  | S time' =>
+    match l with
+    | [] => acc'
+    | _ => fizzleList time' (List.tl l) acc'
+    end
+  end.
+
+Compute fizzleList 100 (seq 1 100) "".


### PR DESCRIPTION
This solution solves the FizzBuzz problem using the theorem proving language Coq.
The code is probably horrible, as this is the first piece of code that I've written in this language.

It creates this output when run:
```
$ coqc solution.v
     = " 1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz 16 17 Fizz 19 Buzz Fizz 22 23 Fizz Buzz 26 Fizz 28 29 FizzBuzz 31 32 Fizz 34 Buzz Fizz 37 38 Fizz Buzz 41 Fizz 43 44 FizzBuzz 46 47 Fizz 49 Buzz Fizz 52 53 Fizz Buzz 56 Fizz 58 59 FizzBuzz 61 62 Fizz 64 Buzz Fizz 67 68 Fizz Buzz 71 Fizz 73 74 FizzBuzz 76 77 Fizz 79 Buzz Fizz 82 83 Fizz Buzz 86 Fizz 88 89 FizzBuzz 91 92 Fizz 94 Buzz Fizz 97 98 Fizz Buzz "%string
     : string
```